### PR TITLE
Issue #50 - Ben - closing connection after publishing. Added test to DeckPublish.

### DIFF
--- a/src/UI/app/components/BackendService/BackendService.js
+++ b/src/UI/app/components/BackendService/BackendService.js
@@ -25,12 +25,17 @@ angular.module('txcmaker')
   };
 
   service.channelToken = "";
+  service.socket = null;
 
   service.openChannel = function(messageHandler) {
     var channel = new goog.appengine.Channel(service.channelToken);
     service.socket = channel.open();
     service.socket.onmessage = messageHandler;
   };
+
+  service.closeChannel = function() {
+    service.socket.close();
+  }
 
   service.updateHandler = function(messageHandler) {
     service.socket.onmessage = messageHandler;

--- a/src/UI/app/components/BackendService/BackendService.mock.js
+++ b/src/UI/app/components/BackendService/BackendService.mock.js
@@ -51,7 +51,27 @@ angular.module('mock.BackendService', [])
           }
         });
       },
-      openChannelCalled: false
+      openChannelCalled: false,
+
+      updateHandler: function(messageHandler) {
+        messageHandler({
+          data: {
+            downloadUrl: "http://downloadUrl.com",
+            deck: {
+              language_label: "stubbed deck.language_label",
+              languages: [
+                {language_label: "translated language 1"},
+                {language_label: "translated language 2"}
+              ]
+            }
+          }
+        });
+      },
+
+      closeChannel: function() {
+        this.closeChannelCalled = true;
+      },
+      closeChannelCalled: false
     };
 
 

--- a/src/UI/app/views/DeckPublish/DeckPublish.ctrl.js
+++ b/src/UI/app/views/DeckPublish/DeckPublish.ctrl.js
@@ -14,6 +14,7 @@ function DeckPublishController($scope, BackendService) {
       $scope.destinationLanguages.push(language.language_label);
     });
     $scope.$apply();
+    BackendService.closeChannel();
   };
 
   (function fetchDeck() {

--- a/src/UI/app/views/DeckPublish/DeckPublish.spec.js
+++ b/src/UI/app/views/DeckPublish/DeckPublish.spec.js
@@ -1,0 +1,23 @@
+describe('DeckPublishController', function() {
+
+  beforeEach(module('txcmaker'));
+  beforeEach(module('mock.BackendService'));
+
+  beforeEach(inject(function(_$controller_, _$timeout_, $rootScope, _BackendService_) {
+    this.$timeout = _$timeout_;
+    this.backendService = _BackendService_;
+    this.$scope = $rootScope;
+    this.$controller = _$controller_;
+
+    this.deckPreviewController = this.$controller('DeckPublishCtrl', {
+      $scope: $rootScope,
+      BackendService: this.backendService,
+      $timeout: this.$timeout
+    });
+  }));
+
+  it('should close the channel after publishing', function() {
+    expect(this.backendService.closeChannelCalled).toBe(true);
+  });
+
+});

--- a/src/UI/karma.conf.js
+++ b/src/UI/karma.conf.js
@@ -20,6 +20,8 @@ module.exports = function(config) {
       'views/DeckImport/DeckImport.spec.js',
       'views/DeckPreview/DeckPreview.ctrl.js',
       'views/DeckPreview/DeckPreview.spec.js',
+      'views/DeckPublish/DeckPublish.ctrl.js',
+      'views/DeckPublish/DeckPublish.spec.js',
       // Then, load dependencies of the module
       'components/BackendService/BackendService.js',
       'components/BackendService/BackendService.mock.js',


### PR DESCRIPTION
Channel's socket will now be closed after publishing. 
It's possible that we want to close the channel's socket after preview, and then re-open it for publishing. 
In development I see the browser polling, and closing the socket stops this. However, based on [this comment](https://groups.google.com/d/msg/google-appengine/XywkK4HpZT4/sm7-SEeflrIJ) AppEngine uses a better alternative to polling when in a production environment. 
So I think it's not a big deal that it's polling in a development environment. But it's a good idea to close the connection after publishing, as no server actions can be taken after that, so there's no reason to keep the connection.
