### PR TITLE
#59 Additional validation for audio files. 

### DIFF
--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/Card.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/Card.java
@@ -1,22 +1,15 @@
 package org.mercycorps.translationcards.txcmaker.model;
 
-import org.mercycorps.translationcards.txcmaker.model.deck.RequiredString;
-import org.mercycorps.translationcards.txcmaker.model.importDeckForm.Constraint;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-public class Card {
+import static com.google.common.collect.Lists.newArrayList;
 
-    public final static Error NO_LABEL = new Error("This card has no label", true);
-    public final static Error NO_AUDIO = new Error("This card has no audio recording", true);
-    public final static Error NO_TEXT = new Error("This card has no text translation", false);
+public class Card {
 
     public String card_label;
     public String dest_audio;
     public String dest_txt;
-    List<Error> errors;
+    public List<Error> errors = newArrayList();
 
     public Card setLabel(String label) {
         this.card_label = label;
@@ -31,21 +24,5 @@ public class Card {
     public Card setTranslationText(String translationText) {
         this.dest_txt = translationText;
         return this;
-    }
-
-    public List<Error> verify() {
-        List<Constraint> constraints = Arrays.asList((Constraint)
-                        new RequiredString(card_label, NO_LABEL),
-                        new RequiredString(dest_audio, NO_AUDIO),
-                        new RequiredString(dest_txt, NO_TEXT)
-        );
-
-        errors = new ArrayList<>();
-
-        for(Constraint constraint : constraints) {
-            errors.addAll(constraint.verify());
-        }
-
-        return errors;
     }
 }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/Card.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/Card.java
@@ -9,7 +9,11 @@ public class Card {
     public String card_label;
     public String dest_audio;
     public String dest_txt;
-    public List<Error> errors = newArrayList();
+    public List<Error> errors;
+
+    public Card() {
+        errors = newArrayList();
+    }
 
     public Card setLabel(String label) {
         this.card_label = label;

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/DeckSerializer.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/DeckSerializer.java
@@ -20,7 +20,7 @@ public class DeckSerializer implements JsonSerializer<Deck> {
         jsonObject.addProperty("timestamp", deck.timestamp);
         jsonObject.addProperty("locked", deck.locked);
         jsonObject.addProperty("license_url", deck.license_url);
-        jsonObject.addProperty("numberOfErrors", deck.numberOfErrors);
+        jsonObject.addProperty("numberOfErrors", deck.getNumberOfErrors());
         jsonObject.add("languages", jsonSerializationContext.serialize(deck.languages));
         return  jsonObject;
     }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/Language.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/Language.java
@@ -26,12 +26,4 @@ public class Language {
         cards.add(card);
         return this;
     }
-
-    public List<Error> verify() {
-        List<Error> errors = new ArrayList<>();
-        for(Card card : cards) {
-            errors.addAll(card.verify());
-        }
-        return errors;
-    }
 }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/deck/Deck.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/deck/Deck.java
@@ -23,14 +23,12 @@ public class Deck {
     public List<Language> languages;
     public List<Error> errors;
     public transient List<Error> parseErrors;
-    public int numberOfErrors;
     private transient Map<String, Language> languageLookup;
 
     public Deck() {
         languages = new ArrayList<>();
         errors = new ArrayList<>();
         parseErrors = new ArrayList<>();
-        numberOfErrors = 0;
         languageLookup = new HashMap<>();
     }
 
@@ -95,11 +93,9 @@ public class Deck {
                 .setLanguageLabel("English");
     }
 
-    public void verify() {
-        for(Language language : languages) {
-            errors.addAll(language.verify());
-        }
-        numberOfErrors = errors.size();
+
+    public int getNumberOfErrors() {
+        return errors.size();
     }
 
 }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardService.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.springframework.util.StringUtils.isEmpty;
@@ -18,7 +19,6 @@ public class VerifyCardService {
     public final static Error NO_AUDIO = new Error("This card has no audio recording", true);
     public final static Error NO_TEXT = new Error("This card has no text translation", false);
     public final static String FILE_NOT_FOUND_ERROR_FORMAT = "There is no file named '%s' in the Google Drive folder.";
-    public final static String DUPLICATE_FILE_ERROR_FORMAT = "Audio file '%s' is associated with more than one card.";
 
 
     public List<Error> verifyRequiredValues(Card card) {
@@ -44,12 +44,5 @@ public class VerifyCardService {
         }
         return null;
     }
-
-    public Error verifyDuplicateAudioFile(Card card, List<String> filesFromCards) {
-        if (filesFromCards.contains(card.dest_audio)) {
-            Error cardError = new Error(String.format(DUPLICATE_FILE_ERROR_FORMAT, card.dest_audio), false);
-            return cardError;
-        }
-        return null;
-    }
 }
+

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardService.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardService.java
@@ -1,0 +1,55 @@
+package org.mercycorps.translationcards.txcmaker.service;
+
+import org.mercycorps.translationcards.txcmaker.model.Card;
+import org.mercycorps.translationcards.txcmaker.model.Error;
+import org.mercycorps.translationcards.txcmaker.model.deck.RequiredString;
+import org.mercycorps.translationcards.txcmaker.model.importDeckForm.Constraint;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.springframework.util.StringUtils.isEmpty;
+
+@Service
+public class VerifyCardService {
+    public final static Error NO_LABEL = new Error("This card has no label", true);
+    public final static Error NO_AUDIO = new Error("This card has no audio recording", true);
+    public final static Error NO_TEXT = new Error("This card has no text translation", false);
+    public final static String FILE_NOT_FOUND_ERROR_FORMAT = "There is no file named '%s' in the Google Drive folder.";
+    public final static String DUPLICATE_FILE_ERROR_FORMAT = "Audio file '%s' is associated with more than one card.";
+
+
+    public List<Error> verifyRequiredValues(Card card) {
+        List<Constraint> constraints = Arrays.asList((Constraint)
+                new RequiredString(card.card_label, NO_LABEL),
+                new RequiredString(card.dest_audio, NO_AUDIO),
+                new RequiredString(card.dest_txt, NO_TEXT)
+        );
+
+        List<Error> errors = newArrayList();
+
+        for(Constraint constraint : constraints) {
+            errors.addAll(constraint.verify());
+        }
+
+        return errors;
+    }
+
+    public Error verifyAudioFilename(Card card, List<String> audioFilenames) {
+        String cardAudioFilename = card.dest_audio;
+        if (audioFilenames == null || !isEmpty(cardAudioFilename) && !audioFilenames.contains(cardAudioFilename)) {
+            return new Error(String.format(FILE_NOT_FOUND_ERROR_FORMAT, cardAudioFilename), true);
+        }
+        return null;
+    }
+
+    public Error verifyDuplicateAudioFile(Card card, List<String> filesFromCards) {
+        if (filesFromCards.contains(card.dest_audio)) {
+            Error cardError = new Error(String.format(DUPLICATE_FILE_ERROR_FORMAT, card.dest_audio), false);
+            return cardError;
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyDeckService.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyDeckService.java
@@ -1,0 +1,59 @@
+package org.mercycorps.translationcards.txcmaker.service;
+
+import com.google.api.services.drive.Drive;
+import org.mercycorps.translationcards.txcmaker.model.Card;
+import org.mercycorps.translationcards.txcmaker.model.Error;
+import org.mercycorps.translationcards.txcmaker.model.Language;
+import org.mercycorps.translationcards.txcmaker.model.deck.Deck;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+
+@Service
+public class VerifyDeckService {
+
+    @Autowired
+    private DriveService driveService;
+
+    @Autowired
+    private VerifyCardService verifyCardService;
+
+    public VerifyDeckService(DriveService driveService, VerifyCardService verifyCardService) {
+        this.driveService = driveService;
+        this.verifyCardService = verifyCardService;
+    }
+
+    public List<Error> verify(Drive drive, Deck deck, String audioDirectoryId) {
+        List<Error> errors = newArrayList();
+        List<String> filenamesInAudioDirectory = driveService.getFilenamesInAudioDirectory(drive, audioDirectoryId);
+        List<String> filesFromCards = newArrayList();
+
+        for (Language language: deck.languages) {
+            for (Card card : language.cards) {
+                List<Error> cardErrors = newArrayList();
+                cardErrors.addAll(verifyCardService.verifyRequiredValues(card));
+
+                Error verifyAudioError = verifyCardService.verifyAudioFilename(card, filenamesInAudioDirectory);
+                if (verifyAudioError != null) {
+                    cardErrors.add(verifyAudioError);
+                }
+
+                Error verifyDupeError = verifyCardService.verifyDuplicateAudioFile(card, filesFromCards);
+                if (verifyDupeError != null) {
+                    cardErrors.add(verifyDupeError);
+                }
+                filesFromCards.add(card.dest_audio);
+
+                card.errors.addAll(cardErrors);
+                errors.addAll(cardErrors);
+            }
+        }
+
+        return errors;
+    }
+}

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyDeckService.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/service/VerifyDeckService.java
@@ -8,14 +8,16 @@ import org.mercycorps.translationcards.txcmaker.model.deck.Deck;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-
 import java.util.List;
+import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Maps.newHashMap;
 
 
 @Service
 public class VerifyDeckService {
+    public final static String DUPLICATE_FILE_ERROR_FORMAT = "Audio file '%s' is associated with more than one card.";
 
     @Autowired
     private DriveService driveService;
@@ -31,7 +33,7 @@ public class VerifyDeckService {
     public List<Error> verify(Drive drive, Deck deck, String audioDirectoryId) {
         List<Error> errors = newArrayList();
         List<String> filenamesInAudioDirectory = driveService.getFilenamesInAudioDirectory(drive, audioDirectoryId);
-        List<String> filesFromCards = newArrayList();
+        Map<String, List<Card>> audioFileToCards = newHashMap();
 
         for (Language language: deck.languages) {
             for (Card card : language.cards) {
@@ -43,17 +45,40 @@ public class VerifyDeckService {
                     cardErrors.add(verifyAudioError);
                 }
 
-                Error verifyDupeError = verifyCardService.verifyDuplicateAudioFile(card, filesFromCards);
-                if (verifyDupeError != null) {
-                    cardErrors.add(verifyDupeError);
-                }
-                filesFromCards.add(card.dest_audio);
+                addToAudioFileMap(card, audioFileToCards);
 
                 card.errors.addAll(cardErrors);
                 errors.addAll(cardErrors);
             }
         }
 
+        errors.addAll(verifyDuplicateAudioFile(audioFileToCards));
+
         return errors;
+    }
+
+    private List<Error> verifyDuplicateAudioFile(Map<String, List<Card>> audioFileMap) {
+        Error error;
+        List<Error> duplicateAudioErrors = newArrayList();
+
+        for (List<Card> cardsForFile : audioFileMap.values()) {
+            if (cardsForFile.size() > 1) {
+                for(Card card : cardsForFile) {
+                    error = new Error(String.format(DUPLICATE_FILE_ERROR_FORMAT, card.dest_audio), true);
+                    card.errors.add(error);
+                    duplicateAudioErrors.add(error);
+                }
+            }
+        }
+        return duplicateAudioErrors;
+    }
+
+    private void addToAudioFileMap(Card card, Map<String, List<Card>> audioFileMap) {
+        List<Card> cardList = audioFileMap.get(card.dest_audio);
+        if (cardList == null) {
+            cardList = newArrayList();
+            audioFileMap.put(card.dest_audio, cardList);
+        }
+        cardList.add(card);
     }
 }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/task/VerifyDeckTask.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/task/VerifyDeckTask.java
@@ -8,6 +8,7 @@ import org.mercycorps.translationcards.txcmaker.model.deck.Deck;
 import org.mercycorps.translationcards.txcmaker.model.deck.DeckMetadata;
 import org.mercycorps.translationcards.txcmaker.service.DriveService;
 import org.mercycorps.translationcards.txcmaker.service.StorageService;
+import org.mercycorps.translationcards.txcmaker.service.VerifyDeckService;
 import org.mercycorps.translationcards.txcmaker.wrapper.GsonWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,15 +31,18 @@ public class VerifyDeckTask {
     private ChannelService channelService;
     private GsonWrapper gsonWrapper;
     private StorageService storageService;
+    private VerifyDeckService verifyDeckService;
 
     @Autowired
-    public VerifyDeckTask(ServletContext servletContext, AuthUtils authUtils, DriveService driveService, ChannelService channelService, GsonWrapper gsonWrapper, StorageService storageService) {
+    public VerifyDeckTask(ServletContext servletContext, AuthUtils authUtils, DriveService driveService, ChannelService channelService,
+                          GsonWrapper gsonWrapper, StorageService storageService, VerifyDeckService verifyDeckService) {
         this.servletContext = servletContext;
         this.authUtils = authUtils;
         this.driveService = driveService;
         this.channelService = channelService;
         this.gsonWrapper = gsonWrapper;
         this.storageService = storageService;
+        this.verifyDeckService = verifyDeckService;
     }
 
     @RequestMapping(method = RequestMethod.POST)
@@ -49,7 +53,7 @@ public class VerifyDeckTask {
         final Drive drive = getDrive(sessionId);
 
         final Deck deck = driveService.assembleDeck(request, sessionId, documentId, drive);
-        deck.verify();
+        deck.errors = verifyDeckService.verify(drive, deck, directoryId);
 
         Map<String, String> audioFiles = driveService.downloadAllAudioFileMetaData(drive, directoryId, deck);
         driveService.downloadAudioFiles(drive, audioFiles, sessionId);

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/model/DeckSerializerTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/model/DeckSerializerTest.java
@@ -1,0 +1,31 @@
+package org.mercycorps.translationcards.txcmaker.model;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import org.junit.Test;
+import org.mercycorps.translationcards.txcmaker.model.deck.Deck;
+
+import java.lang.reflect.Type;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+
+public class DeckSerializerTest {
+
+    @Test
+    public void testNumberOfErrors() throws Exception {
+
+        JsonSerializationContext mockJsonSerializationContext = mock(JsonSerializationContext.class);
+        Type mockType = mock(Type.class);
+        Deck deck = new Deck();
+        Error error1 = new Error("test error 1", true);
+        Error error2 = new Error("test error 2", true);
+        deck.errors = newArrayList(error1, error2);
+        DeckSerializer serializer = new DeckSerializer();
+        JsonObject result = (JsonObject)serializer.serialize(deck, mockType, mockJsonSerializationContext);
+        assertThat(result.get("numberOfErrors").getAsInt(), is(2));
+    }
+}

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/model/deck/DeckTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/model/deck/DeckTest.java
@@ -3,7 +3,9 @@ package org.mercycorps.translationcards.txcmaker.model.deck;
 import org.junit.Before;
 import org.junit.Test;
 import org.mercycorps.translationcards.txcmaker.model.Card;
+import org.mercycorps.translationcards.txcmaker.model.Error;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
@@ -51,6 +53,12 @@ public class DeckTest {
         assertThat(deck.languages.get(0).iso_code, is("ar"));
         assertThat(deck.languages.get(0).cards.get(0), is(card1));
         assertThat(deck.languages.get(0).cards.get(1), is(card2));
+    }
+
+    @Test
+    public void shouldReturnNumberOfErrors() {
+        deck.errors = newArrayList(new Error("error message 1", true), new Error("error message 2", true));
+        assertThat(deck.getNumberOfErrors(), is(2));
     }
 
 

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardServiceTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardServiceTest.java
@@ -1,0 +1,87 @@
+package org.mercycorps.translationcards.txcmaker.service;
+
+import org.junit.Test;
+import org.mercycorps.translationcards.txcmaker.model.Card;
+import org.mercycorps.translationcards.txcmaker.model.Error;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mercycorps.translationcards.txcmaker.service.VerifyCardService.*;
+
+public class VerifyCardServiceTest {
+
+    private VerifyCardService vcs = new VerifyCardService();
+
+    @Test
+    public void testWhenNoRequiredValuesPopulated() {
+
+        Card card = new Card();
+
+        List<Error> actualErrors = vcs.verifyRequiredValues(card);
+
+        assertThat(actualErrors.size(), is(3));
+        assertThat(actualErrors.get(0), is(NO_LABEL));
+        assertThat(actualErrors.get(1), is(NO_AUDIO));
+        assertThat(actualErrors.get(2), is(NO_TEXT));
+    }
+
+    @Test
+    public void testMatchingAudioFile() throws Exception {
+        Card card = new Card();
+        card.dest_audio = "matchingFilename.mp3";
+        List<String> audioFilenames = newArrayList("matchingFilename.mp3", "nonMatching.mp3");
+        Error error = vcs.verifyAudioFilename(card, audioFilenames);
+        assertThat(error, nullValue());
+    }
+
+    @Test
+    public void testNoMatchingFile() throws Exception {
+        List<String> audioFilenames = newArrayList("audioFile1.mp3", "audioFile2.mp3");
+        Card card = new Card();
+        card.dest_audio = "fileNotInDirectory.mp3";
+        Error error = vcs.verifyAudioFilename(card, audioFilenames);
+        assertThat(error.message, is(String.format(FILE_NOT_FOUND_ERROR_FORMAT, card.dest_audio)));
+    }
+
+    @Test
+    public void testNoFilesInDir() throws Exception {
+        List<String> audioFilenames = newArrayList();
+        Card card = new Card();
+        card.dest_audio  = "fileNotInDirectory.mp3";
+        Error error = vcs.verifyAudioFilename(card, audioFilenames);
+        assertThat(error.message, is(String.format(FILE_NOT_FOUND_ERROR_FORMAT, card.dest_audio)));
+    }
+
+    @Test
+    public void testNullDirFiles() throws Exception {
+        List<String> audioFilenames = null;
+        Card card = new Card();
+        card.dest_audio  = "fileNotInDirectory.mp3";
+        Error error = vcs.verifyAudioFilename(card, audioFilenames);
+        assertThat(error.message, is(String.format(FILE_NOT_FOUND_ERROR_FORMAT, card.dest_audio)));
+    }
+
+    @Test
+    public void testNonEnglishChars() throws Exception {
+        String funChars = "ñéحيبε好";
+        List<String> audioFilenames = newArrayList(funChars);
+        Card card = new Card();
+        card.dest_audio  = funChars;
+        Error error = vcs.verifyAudioFilename(card, audioFilenames);
+        assertThat(error, nullValue());
+    }
+
+    @Test
+    public void testWhenAudioFileIsADuplicate() {
+        Card card = new Card();
+        card.dest_audio = "sameFile.mp3";
+
+        List<String> existingCardFiles = newArrayList("sameFile.mp3","differentFile.mp3" );
+
+        assertThat(vcs.verifyDuplicateAudioFile(card, existingCardFiles).message, is(String.format(DUPLICATE_FILE_ERROR_FORMAT, card.dest_audio)));
+    }
+}

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardServiceTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/service/VerifyCardServiceTest.java
@@ -74,14 +74,4 @@ public class VerifyCardServiceTest {
         Error error = vcs.verifyAudioFilename(card, audioFilenames);
         assertThat(error, nullValue());
     }
-
-    @Test
-    public void testWhenAudioFileIsADuplicate() {
-        Card card = new Card();
-        card.dest_audio = "sameFile.mp3";
-
-        List<String> existingCardFiles = newArrayList("sameFile.mp3","differentFile.mp3" );
-
-        assertThat(vcs.verifyDuplicateAudioFile(card, existingCardFiles).message, is(String.format(DUPLICATE_FILE_ERROR_FORMAT, card.dest_audio)));
-    }
 }

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/service/VerifyDeckServiceTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/service/VerifyDeckServiceTest.java
@@ -1,0 +1,116 @@
+package org.mercycorps.translationcards.txcmaker.service;
+
+import com.google.api.services.drive.Drive;
+import org.junit.Before;
+import org.junit.Test;
+import org.mercycorps.translationcards.txcmaker.model.Card;
+import org.mercycorps.translationcards.txcmaker.model.Error;
+import org.mercycorps.translationcards.txcmaker.model.Language;
+import org.mercycorps.translationcards.txcmaker.model.deck.Deck;
+import org.mockito.Mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class VerifyDeckServiceTest {
+
+    @Mock
+    Drive mockDrive;
+
+    @Mock
+    DriveService mockDriveService;
+
+    @Mock
+    VerifyCardService mockVerifyCardService;
+
+    String audioDirectoryId;
+
+
+    @Before
+    public void setup() {
+        initMocks(this);
+
+        audioDirectoryId = "doesNotMatterWhatThisValueIs";
+    }
+
+
+    @Test
+    public void testFailedVerifications() {
+
+        when(mockVerifyCardService.verifyRequiredValues(any(Card.class))).thenReturn(newArrayList(new Error("requiredValuesError", true)));
+        when(mockVerifyCardService.verifyAudioFilename(any(Card.class), any(List.class))).thenReturn(new Error("audioFilenameError", true));
+        when(mockVerifyCardService.verifyDuplicateAudioFile(any(Card.class), any(List.class))).thenReturn(new Error("duplicateFilenameError", true));
+
+        VerifyDeckService verifyDeckService = new VerifyDeckService(mockDriveService, mockVerifyCardService);
+        Deck deck = new Deck();
+        Language language = new Language();
+
+        Card card1 = new Card();
+        language.addCard(card1);
+
+        deck.languages = newArrayList(language);
+        List<Error> actualErrors = verifyDeckService.verify(mockDrive, deck, audioDirectoryId);
+
+        assertThat(actualErrors.size(), is(3));
+    }
+
+    @Test
+    public void testPassingVerifications() {
+
+        when(mockVerifyCardService.verifyRequiredValues(any(Card.class))).thenReturn(new ArrayList<Error>());
+        when(mockVerifyCardService.verifyAudioFilename(any(Card.class), any(List.class))).thenReturn(null);
+        when(mockVerifyCardService.verifyDuplicateAudioFile(any(Card.class), any(List.class))).thenReturn(null);
+
+        VerifyDeckService verifyDeckService = new VerifyDeckService(mockDriveService, mockVerifyCardService);
+        Deck deck = new Deck();
+        Language language = new Language();
+
+        Card card1 = new Card();
+        language.addCard(card1);
+
+        deck.languages = newArrayList(language);
+        List<Error> actualErrors = verifyDeckService.verify(mockDrive, deck, audioDirectoryId);
+
+        assertThat(actualErrors.size(), is(0));
+    }
+
+    @Test
+    public void testErrorsAreAddedToCards() {
+        Card requiredValueErrorCard = new Card();
+        Card audioFileErrorCard = new Card();
+        Card dupeFileErrorCard = new Card();
+
+        when(mockVerifyCardService.verifyRequiredValues(requiredValueErrorCard)).thenReturn(newArrayList(new Error("requiredValuesError", true)));
+        when(mockVerifyCardService.verifyAudioFilename(eq(audioFileErrorCard), any(List.class))).thenReturn(new Error("audioFilenameError", true));
+        when(mockVerifyCardService.verifyDuplicateAudioFile(eq(dupeFileErrorCard), any(List.class))).thenReturn(new Error("duplicateFilenameError", true));
+
+        VerifyDeckService verifyDeckService = new VerifyDeckService(mockDriveService, mockVerifyCardService);
+
+        Language language = new Language();
+        language.addCard(requiredValueErrorCard);
+        language.addCard(audioFileErrorCard);
+        language.addCard(dupeFileErrorCard);
+
+        Deck deck = new Deck();
+        deck.languages = newArrayList(language);
+
+        verifyDeckService.verify(mockDrive, deck, audioDirectoryId);
+
+        assertThat(requiredValueErrorCard.errors.size(), is(1));
+        assertThat(requiredValueErrorCard.errors.get(0).message, is("requiredValuesError"));
+
+        assertThat(audioFileErrorCard.errors.size(), is(1));
+        assertThat(audioFileErrorCard.errors.get(0).message, is("audioFilenameError"));
+
+        assertThat(dupeFileErrorCard.errors.size(), is(1));
+        assertThat(dupeFileErrorCard.errors.get(0).message, is("duplicateFilenameError"));
+    }
+}

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/task/VerifyDeckTaskTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/task/VerifyDeckTaskTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mercycorps.translationcards.txcmaker.auth.AuthUtils;
 import org.mercycorps.translationcards.txcmaker.language.LanguageService;
 import org.mercycorps.translationcards.txcmaker.model.deck.Deck;
+import org.mercycorps.translationcards.txcmaker.model.Error;
 import org.mercycorps.translationcards.txcmaker.service.DriveService;
 import org.mercycorps.translationcards.txcmaker.service.StorageService;
 import org.mercycorps.translationcards.txcmaker.service.VerifyDeckService;
@@ -26,6 +27,7 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
@@ -170,5 +172,14 @@ public class VerifyDeckTaskTest {
         verifyDeckTask.verifyDeck(request);
 
         verify(verifyDeckService).verify(drive, deck, AUDIO_DIR_ID);
+    }
+
+    @Test
+    public void shouldAddErrorsToDeck() throws Exception {
+        when(verifyDeckService.verify(drive, deck, AUDIO_DIR_ID)).thenReturn(newArrayList(new Error("a deck error", false)));
+        verifyDeckTask.verifyDeck(request);
+        assertThat(deck.errors.size(), is(1));
+
+        assertThat(deck.errors.get(0).message, is("a deck error"));
     }
 }

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/task/VerifyDeckTaskTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/task/VerifyDeckTaskTest.java
@@ -12,6 +12,7 @@ import org.mercycorps.translationcards.txcmaker.language.LanguageService;
 import org.mercycorps.translationcards.txcmaker.model.deck.Deck;
 import org.mercycorps.translationcards.txcmaker.service.DriveService;
 import org.mercycorps.translationcards.txcmaker.service.StorageService;
+import org.mercycorps.translationcards.txcmaker.service.VerifyDeckService;
 import org.mercycorps.translationcards.txcmaker.wrapper.GsonWrapper;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -59,6 +60,8 @@ public class VerifyDeckTaskTest {
     private GsonWrapper gsonWrapper;
     @Mock
     private StorageService storageService;
+    @Mock
+    private VerifyDeckService verifyDeckService;
 
     private VerifyDeckTask verifyDeckTask;
     private Map<String, String> audioFileMetaData;
@@ -95,7 +98,7 @@ public class VerifyDeckTaskTest {
         when(driveService.downloadAllAudioFileMetaData(drive, AUDIO_DIR_ID, deck))
                 .thenReturn(audioFileMetaData);
 
-        verifyDeckTask = new VerifyDeckTask(servletContext, authUtils, driveService, channelService, gsonWrapper, storageService);
+        verifyDeckTask = new VerifyDeckTask(servletContext, authUtils, driveService, channelService, gsonWrapper, storageService, verifyDeckService);
     }
 
     @Test
@@ -160,5 +163,12 @@ public class VerifyDeckTaskTest {
         verifyDeckTask.verifyDeck(request);
 
         verify(driveService).downloadAudioFiles(drive, audioFileMetaData, SESSION_ID);
+    }
+
+    @Test
+    public void shouldVerifyUsingService() throws Exception {
+        verifyDeckTask.verifyDeck(request);
+
+        verify(verifyDeckService).verify(drive, deck, AUDIO_DIR_ID);
     }
 }


### PR DESCRIPTION
Moved deck and card validation into service. Added Tests.

Two new validations:
- verify the files referenced in the spreadsheet exist in the audio file. This is marked as a fatal error.
- verify if an audio file is used twice. Non-fatal.

I moved the verify() methods out of Deck, Language, and Cards to keep them as dumb as possible. Put the verify logic into VerifyDeckService and VerifyCardService. Language.verify() was just calling the card.verify() so that's done in VerifyDeckService now. 
That refactor should allow future verifications without bloating the model classes.

Please comment! No comment is too small. 
