### PR TITLE
Coleman #56 - Remove duplicate errors when submitting empty Document …

### DIFF
--- a/src/UI/bower.json
+++ b/src/UI/bower.json
@@ -6,12 +6,15 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "~1.5.0",
-    "angular-route": "~1.5.0",
-    "angular-loader": "~1.5.0",
-    "angular-mocks": "~1.5.0",
+    "angular": "~1.5.10",
+    "angular-route": "~1.5.10",
+    "angular-loader": "~1.5.10",
+    "angular-mocks": "~1.5.10",
     "html5-boilerplate": "^5.3.0",
-    "angular-material": "~1.0.9",
-    "angular-css": "^1.0.8"
+    "angular-material": "~1.1.1",
+    "angular-css": "~1.0.8"
+  },
+  "resolutions": {
+    "angular": "1.6.1"
   }
 }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ImportDeckForm.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ImportDeckForm.java
@@ -10,10 +10,8 @@ import java.util.List;
 
 public class ImportDeckForm {
 
-    public static final Error NO_DECK_NAME = new Error("Deck name is a required field", true);
-    public static final Error NO_PUBLISHER = new Error("Publisher is a required field", true);
-    public static final Error NO_DOC_ID = new Error("Document ID is a required field", true);
-    public static final Error NO_AUDIO_DIR_ID = new Error("Audio Directory ID is a required field", true);
+    private static final Error NO_DECK_NAME = new Error("Deck name is a required field", true);
+    private static final Error NO_PUBLISHER = new Error("Publisher is a required field", true);
 
     private String docId;
     private String audioDirId;
@@ -88,12 +86,10 @@ public class ImportDeckForm {
 
     public List<Constraint> getFieldsToVerify(Drive drive) {
         List<Constraint> constraints = new ArrayList<>();
-        constraints.add(new ValidDocumentId(drive, getDocId()));
-        constraints.add(new ValidAudioDirectory(drive, getAudioDirId()));
         constraints.add(new RequiredString(getDeckName(), NO_DECK_NAME));
         constraints.add(new RequiredString(getPublisher(), NO_PUBLISHER));
-        constraints.add(new RequiredString(getDocId(), NO_DOC_ID));
-        constraints.add(new RequiredString(getAudioDirId(), NO_AUDIO_DIR_ID));
+        constraints.add(new ValidDocumentId(drive, getDocId()));
+        constraints.add(new ValidAudioDirectory(drive, getAudioDirId()));
 
         return constraints;
     }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidAudioDirectory.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidAudioDirectory.java
@@ -3,13 +3,15 @@ package org.mercycorps.translationcards.txcmaker.model.importDeckForm;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.drive.Drive;
 import org.mercycorps.translationcards.txcmaker.model.Error;
+import org.mercycorps.translationcards.txcmaker.model.deck.RequiredString;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class ValidAudioDirectory implements Constraint {
-    public static final Error INVALID_AUDIO_DIRECTORY_ID = new Error("Invalid Audio Directory ID", true);
+    static final Error INVALID_AUDIO_DIRECTORY_ID = new Error("Invalid Audio Directory ID", true);
+    static final Error NO_AUDIO_DIR_ID = new Error("Audio Directory ID is a required field", true);
+    private final RequiredString emptyDirectoryID;
 
     private Drive drive;
     private String audioDirectoryId;
@@ -17,19 +19,23 @@ public class ValidAudioDirectory implements Constraint {
     public ValidAudioDirectory(Drive drive, String audioDirectoryId) {
         this.drive = drive;
         this.audioDirectoryId = audioDirectoryId;
+        this.emptyDirectoryID = new RequiredString(audioDirectoryId, NO_AUDIO_DIR_ID);
     }
 
     @Override
     public List<Error> verify() {
-        List<Error> errors = new ArrayList<>();
+        List<Error> errors = emptyDirectoryID.verify();
 
-        try {
-            drive.children().list(audioDirectoryId).execute();
-        } catch(GoogleJsonResponseException e) {
-            errors.add(INVALID_AUDIO_DIRECTORY_ID);
-        } catch(IOException e) {
-            errors.add(ValidDocumentId.FATAL_DRIVE_ERROR);
+        if (errors.isEmpty()) {
+            try {
+                drive.children().list(audioDirectoryId).execute();
+            } catch (GoogleJsonResponseException e) {
+                errors.add(INVALID_AUDIO_DIRECTORY_ID);
+            } catch (IOException e) {
+                errors.add(ValidDocumentId.FATAL_DRIVE_ERROR);
+            }
         }
+
         return errors;
     }
 }

--- a/src/main/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidDocumentId.java
+++ b/src/main/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidDocumentId.java
@@ -4,36 +4,41 @@ package org.mercycorps.translationcards.txcmaker.model.importDeckForm;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.drive.Drive;
 import org.mercycorps.translationcards.txcmaker.model.Error;
+import org.mercycorps.translationcards.txcmaker.model.deck.RequiredString;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class ValidDocumentId implements Constraint {
     public static final String CSV_EXPORT_TYPE = "text/csv";
-    public static final String INVALID_DOCUMENT_ID_MESSAGE = "Invalid Document ID";
-    public static final String FATAL_DRIVE_ERROR_MESSAGE = "There was an error accessing the provided document. Please try again.";
-    public static final Error INVALID_DOCUMENT_ID = new Error(INVALID_DOCUMENT_ID_MESSAGE, true);
-    public static final Error FATAL_DRIVE_ERROR = new Error(FATAL_DRIVE_ERROR_MESSAGE, true);
+    private static final String INVALID_DOCUMENT_ID_MESSAGE = "Invalid Document ID";
+    private static final String FATAL_DRIVE_ERROR_MESSAGE = "There was an error accessing the provided document. Please try again.";
+    static final Error NO_DOC_ID = new Error("Document ID is a required field", true);
+    static final Error INVALID_DOCUMENT_ID = new Error(INVALID_DOCUMENT_ID_MESSAGE, true);
+    static final Error FATAL_DRIVE_ERROR = new Error(FATAL_DRIVE_ERROR_MESSAGE, true);
 
     private Drive drive;
     private String documentId;
+    private RequiredString emptyIDCheck;
 
     public ValidDocumentId(Drive drive, String documentId) {
         this.drive = drive;
         this.documentId = documentId;
+        this.emptyIDCheck = new RequiredString(documentId, NO_DOC_ID);
     }
 
     @Override
     public List<Error> verify() {
-        List<Error> errors = new ArrayList<>();
+        List<Error> errors = emptyIDCheck.verify();
 
-        try {
-            drive.files().export(documentId, CSV_EXPORT_TYPE).executeMediaAsInputStream().close();
-        } catch(GoogleJsonResponseException e) {
-            errors.add(INVALID_DOCUMENT_ID);
-        } catch(IOException e) {
-            errors.add(FATAL_DRIVE_ERROR);
+        if(errors.isEmpty()) {
+            try {
+                drive.files().export(documentId, CSV_EXPORT_TYPE).executeMediaAsInputStream().close();
+            } catch (GoogleJsonResponseException e) {
+                errors.add(INVALID_DOCUMENT_ID);
+            } catch (IOException e) {
+                errors.add(FATAL_DRIVE_ERROR);
+            }
         }
 
         return errors;

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidAudioDirectoryTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidAudioDirectoryTest.java
@@ -1,0 +1,87 @@
+package org.mercycorps.translationcards.txcmaker.model.importDeckForm;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.drive.Drive;
+import org.junit.Before;
+import org.junit.Test;
+import org.mercycorps.translationcards.txcmaker.model.Error;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ValidAudioDirectoryTest {
+
+    private ValidAudioDirectory validAudioDirectory;
+    private Drive drive;
+    private String audioDirectoryIDString;
+    private List<Error> errors;
+
+    @Before
+    public void setup() {
+        errors = new ArrayList<>();
+        drive = mock(Drive.class, RETURNS_DEEP_STUBS);
+        audioDirectoryIDString = "directory ID String";
+        validAudioDirectory = new ValidAudioDirectory(drive, audioDirectoryIDString);
+    }
+
+    @Test
+    public void verifyFormData_shouldNotRespondWithErrorsWhenTheDirectoryIdIsValid() throws Exception {
+        errors.addAll(validAudioDirectory.verify());
+
+        assertThat(errors.isEmpty(), is(true));
+    }
+
+    @Test
+    public void verifyFormData_shouldAddAnErrorWhenDirectoryIDIsInvalid() throws Exception {
+        when(drive.children().list(audioDirectoryIDString).execute())
+                .thenThrow(mock(GoogleJsonResponseException.class));
+
+        errors.addAll(validAudioDirectory.verify());
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors.get(0), is(ValidAudioDirectory.INVALID_AUDIO_DIRECTORY_ID));
+    }
+
+    @Test
+    public void verifyFormData_shouldAddAnErrorWhenThereIsADriveError() throws Exception {
+        when(drive.children().list(audioDirectoryIDString).execute())
+                .thenThrow(new IOException());
+
+        errors.addAll(validAudioDirectory.verify());
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors.get(0), is(ValidDocumentId.FATAL_DRIVE_ERROR));
+    }
+
+    @Test
+    public void verifyFormData_shouldAddAnErrorWhenThereIsAnEmptyID() throws Exception {
+        String emptyDirectoryID = "";
+        when(drive.children().list(emptyDirectoryID).execute())
+                .thenThrow(mock(GoogleJsonResponseException.class));
+        validAudioDirectory = new ValidAudioDirectory(drive, emptyDirectoryID);
+        errors.addAll(validAudioDirectory.verify());
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors.get(0), is(ValidAudioDirectory.NO_AUDIO_DIR_ID));
+    }
+
+    @Test
+    public void verifyFormData_shouldAddAnErrorWhenThereIsANullID() throws Exception {
+        String nullDirectoryID = null;
+        when(drive.children().list(nullDirectoryID).execute())
+                .thenThrow(mock(GoogleJsonResponseException.class));
+        validAudioDirectory = new ValidAudioDirectory(drive, nullDirectoryID);
+        errors.addAll(validAudioDirectory.verify());
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors.get(0), is(ValidAudioDirectory.NO_AUDIO_DIR_ID));
+    }
+
+}

--- a/src/test/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidDocumentIdTest.java
+++ b/src/test/java/org/mercycorps/translationcards/txcmaker/model/importDeckForm/ValidDocumentIdTest.java
@@ -1,11 +1,10 @@
-package org.mercycorps.translationcards.txcmaker.verifier;
+package org.mercycorps.translationcards.txcmaker.model.importDeckForm;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.drive.Drive;
 import org.junit.Before;
 import org.junit.Test;
 import org.mercycorps.translationcards.txcmaker.model.Error;
-import org.mercycorps.translationcards.txcmaker.model.importDeckForm.ValidDocumentId;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -18,7 +17,7 @@ import static org.mockito.Mockito.*;
 public class ValidDocumentIdTest {
 
 
-    ValidDocumentId validDocumentId;
+    private ValidDocumentId validDocumentId;
     private Drive drive;
     private String documentIdString;
     private List<Error> errors;
@@ -58,5 +57,29 @@ public class ValidDocumentIdTest {
 
         assertThat(errors.size(), is(1));
         assertThat(errors.get(0), is(ValidDocumentId.FATAL_DRIVE_ERROR));
+    }
+
+    @Test
+    public void verifyFormData_shouldAddAnErrorWhenThereIsAnEmptyID() throws Exception {
+        String emptyDocID = "";
+        when(drive.files().export(emptyDocID, ValidDocumentId.CSV_EXPORT_TYPE).executeMediaAsInputStream())
+                .thenThrow(mock(GoogleJsonResponseException.class));
+        validDocumentId = new ValidDocumentId(drive, emptyDocID);
+        errors.addAll(validDocumentId.verify());
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors.get(0), is(ValidDocumentId.NO_DOC_ID));
+    }
+
+    @Test
+    public void verifyFormData_shouldAddAnErrorWhenThereIsANullID() throws Exception {
+        String nullDocID = null;
+        when(drive.files().export(nullDocID, ValidDocumentId.CSV_EXPORT_TYPE).executeMediaAsInputStream())
+                .thenThrow(mock(GoogleJsonResponseException.class));
+        validDocumentId = new ValidDocumentId(drive, nullDocID);
+        errors.addAll(validDocumentId.verify());
+
+        assertThat(errors.size(), is(1));
+        assertThat(errors.get(0), is(ValidDocumentId.NO_DOC_ID));
     }
 }


### PR DESCRIPTION
…or Directory ID.

This makes sure that a user will not see both the "Invalid Document ID" and the "Document ID is a required field" when they submit a request with an empty document or audio directory ID.  It also changes the order in which these errors appear to match the order they appear in the actual form.